### PR TITLE
Tactic tracing

### DIFF
--- a/plugins/tactics/src/Ide/Plugin/Tactic.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic.hs
@@ -258,7 +258,6 @@ judgementForHole state nfp range = do
 
   resulting_range <- liftMaybe $ toCurrentRange amapping $ realSrcSpanToRange rss
   (tcmod, _) <- MaybeT $ runIde state $ useWithStale TypeCheck nfp
-  -- traceMX "holes!" $ isRhsHole rss $
   let tcg = fst $ tm_internals_ $ tmrModule tcmod
       tcs = tm_typechecked_source $ tmrModule tcmod
       ctx = mkContext
@@ -297,9 +296,10 @@ tacticCmd tac lf state (TacticParams uri range var_name)
               pure $ (, Nothing)
                 $ Left
                 $ ResponseError InvalidRequest (T.pack $ show err) Nothing
-            Right res -> do
-              let g = graft (RealSrcSpan span) res
+            Right (tr, ext) -> do
+              let g = graft (RealSrcSpan span) ext
                   response = transform dflags (clientCapabilities lf) uri g pm
+              traceMX "trace" tr
               pure $ case response of
                 Right res -> (Right Null , Just (WorkspaceApplyEdit, ApplyWorkspaceEditParams res))
                 Left err -> (Left $ ResponseError InternalError (T.pack err) Nothing, Nothing)

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Auto.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Auto.hs
@@ -3,6 +3,7 @@ module Ide.Plugin.Tactic.Auto where
 import Ide.Plugin.Tactic.Context
 import Ide.Plugin.Tactic.Judgements
 import Ide.Plugin.Tactic.KnownStrategies
+import Ide.Plugin.Tactic.Machinery
 import Ide.Plugin.Tactic.Tactics
 import Ide.Plugin.Tactic.Types
 import Refinery.Tactic
@@ -11,7 +12,7 @@ import Refinery.Tactic
 ------------------------------------------------------------------------------
 -- | Automatically solve a goal.
 auto :: TacticsM ()
-auto = do
+auto = tracing "auto" $ do
   jdg <- goal
   current <- getCurrentDefinitions
   traceMX "goal" jdg

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Auto.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Auto.hs
@@ -3,20 +3,22 @@ module Ide.Plugin.Tactic.Auto where
 import Ide.Plugin.Tactic.Context
 import Ide.Plugin.Tactic.Judgements
 import Ide.Plugin.Tactic.KnownStrategies
-import Ide.Plugin.Tactic.Machinery
 import Ide.Plugin.Tactic.Tactics
 import Ide.Plugin.Tactic.Types
 import Refinery.Tactic
+import Ide.Plugin.Tactic.Machinery (tracing)
 
 
 ------------------------------------------------------------------------------
 -- | Automatically solve a goal.
 auto :: TacticsM ()
-auto = tracing "auto" $ do
+auto = do
   jdg <- goal
   current <- getCurrentDefinitions
   traceMX "goal" jdg
-  commit
-    knownStrategies
-    (localTactic (auto' 4) $ disallowing $ fmap fst current)
+  commit knownStrategies
+    . tracing "auto"
+    . localTactic (auto' 4)
+    . disallowing
+    $ fmap fst current
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FlexibleContexts #-}
 module Ide.Plugin.Tactic.CodeGen where
 
@@ -38,7 +39,7 @@ destructMatches
     -> CType
        -- ^ Type being destructed
     -> Judgement
-    -> RuleM [RawMatch]
+    -> RuleM (Trace, [RawMatch])
 destructMatches f f2 t jdg = do
   let hy = jHypothesis jdg
       g  = jGoal jdg
@@ -48,7 +49,7 @@ destructMatches f f2 t jdg = do
       let dcs = tyConDataCons tc
       case dcs of
         [] -> throwError $ GoalMismatch "destruct" g
-        _ -> for dcs $ \dc -> do
+        _ -> fmap unzipTrace $ for dcs $ \dc -> do
           let args = dataConInstArgTys dc apps
           names <- mkManyGoodNames hy args
           let hy' = zip names $ coerce args
@@ -61,9 +62,15 @@ destructMatches f f2 t jdg = do
                 $ withPositionMapping dcon_name names
                 $ introducingPat hy'
                 $ withNewGoal g jdg
-          sg <- f dc j
+          (tr, sg) <- f dc j
           modify $ withIntroducedVals $ mappend $ S.fromList names
-          pure $ match [pat] $ unLoc sg
+          pure $ (tr, match [pat] $ unLoc sg)
+
+
+unzipTrace :: [(Trace, a)] -> (Trace, [a])
+unzipTrace l =
+  let (trs, as) = unzip l
+   in (rose mempty trs, as)
 
 
 ------------------------------------------------------------------------------
@@ -77,7 +84,7 @@ destruct' f term jdg = do
     Nothing -> throwError $ UndefinedHypothesis term
     Just (_, t) -> do
       useOccName jdg term
-      fmap noLoc $ case' (var' term) <$>
+      fmap (fmap noLoc $ case' (var' term)) <$>
         destructMatches
           f
           (\cs -> setParents term (fmap fst cs) . destructing term)
@@ -94,7 +101,7 @@ destructLambdaCase' f jdg = do
   let g  = jGoal jdg
   case splitFunTy_maybe (unCType g) of
     Just (arg, _) | isAlgType arg ->
-      fmap noLoc $ lambdaCase <$>
+      fmap (fmap noLoc $ lambdaCase) <$>
         destructMatches f (const id) (CType arg) jdg
     _ -> throwError $ GoalMismatch "destructLambdaCase'" g
 
@@ -105,11 +112,13 @@ buildDataCon
     :: Judgement
     -> DataCon            -- ^ The data con to build
     -> [Type]             -- ^ Type arguments for the data con
-    -> RuleM (LHsExpr GhcPs)
+    -> RuleM (Trace, LHsExpr GhcPs)
 buildDataCon jdg dc apps = do
   let args = dataConInstArgTys dc apps
       dcon_name = nameOccName $ dataConName dc
-  sgs <- traverse ( \(arg, n) ->
+  (tr, sgs)
+      <- fmap unzipTrace
+       $ traverse ( \(arg, n) ->
                     newSubgoal
                   . filterSameTypeFromOtherPositions dcon_name n
                   . blacklistingDestruct
@@ -117,6 +126,7 @@ buildDataCon jdg dc apps = do
                   $ CType arg
                   ) $ zip args [0..]
   pure
+    . (tr,)
     . noLoc
     . foldl' (@@)
         (HsVar noExtField $ noLoc $ Unqual $ nameOccName $ dataConName dc)
@@ -127,6 +137,7 @@ buildDataCon jdg dc apps = do
 -- | Like 'var', but works over standard GHC 'OccName's.
 var' :: Var a => OccName -> a
 var' = var . fromString . occNameString
+
 
 ------------------------------------------------------------------------------
 -- | Like 'bvar', but works over standard GHC 'OccName's.

--- a/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies.hs
@@ -8,6 +8,7 @@ import Ide.Plugin.Tactic.Tactics
 import Ide.Plugin.Tactic.Types
 import OccName (mkVarOcc)
 import Refinery.Tactic
+import Ide.Plugin.Tactic.Machinery (tracing)
 
 
 knownStrategies :: TacticsM ()
@@ -19,9 +20,8 @@ knownStrategies = choice
 known :: String -> TacticsM () -> TacticsM ()
 known name t = do
   getCurrentDefinitions >>= \case
-    [(def, _)] | def == mkVarOcc name -> do
-      traceMX "running known strategy" name
-      t
+    [(def, _)] | def == mkVarOcc name ->
+      tracing ("known " <> name) t
     _ -> throwError NoApplicableTactic
 
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
@@ -80,7 +80,7 @@ recursion = tracing "recursion" $ do
 ------------------------------------------------------------------------------
 -- | Introduce a lambda binding every variable.
 intros :: TacticsM ()
-intros = tracing "intros" $ rule $ \jdg -> do
+intros = rule $ \jdg -> do
   let hy = jHypothesis jdg
       g  = jGoal jdg
   ctx <- ask
@@ -100,7 +100,7 @@ intros = tracing "intros" $ rule $ \jdg -> do
               (isTopHole jdg)
           $ jdg'
       pure
-        . (tr, )
+        . (rose ("intros {" <> intercalate ", " (fmap show vs) <> "}") $ pure tr, )
         . noLoc
         . lambda (fmap bvar' vs)
         $ unLoc sg

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
@@ -61,7 +61,7 @@ assume name = rule $ \jdg -> do
             True  -> setRecursionFrameData True
             False -> pure ()
           useOccName jdg name
-          pure $ (tracePrim $ "assume:" <> occNameString name, ) $ noLoc $ var' name
+          pure $ (tracePrim $ "assume " <> occNameString name, ) $ noLoc $ var' name
         False -> throwError $ GoalMismatch "assume" g
     Nothing -> throwError $ UndefinedHypothesis name
 
@@ -161,7 +161,7 @@ apply = apply' (const id)
 
 
 apply' :: (Int -> Judgement -> Judgement) -> OccName -> TacticsM ()
-apply' f func = tracing ("apply':" <> show func) $ do
+apply' f func = tracing ("apply' " <> show func) $ do
   rule $ \jdg -> do
     let hy = jHypothesis jdg
         g  = jGoal jdg

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -26,13 +26,15 @@ import Control.Monad.Reader
 import Data.Function
 import Data.Map (Map)
 import Data.Set (Set)
-import Development.IDE.GHC.Compat
+import Development.IDE.GHC.Compat hiding (Node)
 import Development.IDE.Types.Location
 import GHC.Generics
 import Ide.Plugin.Tactic.Debug
 import OccName
 import Refinery.Tactic
 import Type
+import Data.Tree
+import Data.Coerce
 
 
 ------------------------------------------------------------------------------
@@ -58,6 +60,9 @@ instance Show TCvSubst where
   show  = unsafeRender
 
 instance Show (LHsExpr GhcPs) where
+  show  = unsafeRender
+
+instance Show DataCon where
   show  = unsafeRender
 
 
@@ -118,8 +123,8 @@ newtype ExtractM a = ExtractM { unExtractM :: Reader Context a }
 
 ------------------------------------------------------------------------------
 -- | Orphan instance for producing holes when attempting to solve tactics.
-instance MonadExtract (LHsExpr GhcPs) ExtractM where
-  hole = pure $ noLoc $ HsVar noExtField $ noLoc $ Unqual $ mkVarOcc "_"
+instance MonadExtract (Trace, LHsExpr GhcPs) ExtractM where
+  hole = pure (mempty, noLoc $ HsVar noExtField $ noLoc $ Unqual $ mkVarOcc "_")
 
 
 ------------------------------------------------------------------------------
@@ -175,9 +180,11 @@ instance Show TacticError where
 
 
 ------------------------------------------------------------------------------
-type TacticsM  = TacticT Judgement (LHsExpr GhcPs) TacticError TacticState ExtractM
-type RuleM     = RuleT Judgement (LHsExpr GhcPs) TacticError TacticState ExtractM
-type Rule      = RuleM (LHsExpr GhcPs)
+type TacticsM  = TacticT Judgement (Trace, LHsExpr GhcPs) TacticError TacticState ExtractM
+type RuleM     = RuleT Judgement (Trace, LHsExpr GhcPs) TacticError TacticState ExtractM
+type Rule      = RuleM (Trace, LHsExpr GhcPs)
+
+type Trace = Rose String
 
 
 ------------------------------------------------------------------------------
@@ -189,4 +196,21 @@ data Context = Context
     -- ^ Everything defined in the current module
   }
   deriving stock (Eq, Ord)
+
+
+newtype Rose a = Rose (Tree a)
+  deriving stock (Eq, Functor, Generic)
+
+instance Show (Rose String) where
+  show = drawTree . coerce
+
+instance Semigroup a => Semigroup (Rose a) where
+  Rose (Node a as) <> Rose (Node b bs) = Rose $ Node (a <> b) (as <> bs)
+
+instance Monoid a => Monoid (Rose a) where
+  mempty = Rose $ Node mempty mempty
+
+rose :: (Eq a, Monoid a) => a -> [Rose a] -> Rose a
+rose a [Rose (Node a' rs)] | a' == mempty = Rose $ Node a rs
+rose a rs = Rose $ Node a $ coerce rs
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -202,7 +202,12 @@ newtype Rose a = Rose (Tree a)
   deriving stock (Eq, Functor, Generic)
 
 instance Show (Rose String) where
-  show = drawTree . coerce
+  show = unlines . dropEveryOther . lines . drawTree . coerce
+
+dropEveryOther :: [a] -> [a]
+dropEveryOther []           = []
+dropEveryOther [a]          = [a]
+dropEveryOther (a : _ : as) = a : dropEveryOther as
 
 instance Semigroup a => Semigroup (Rose a) where
   Rose (Node a as) <> Rose (Node b bs) = Rose $ Node (a <> b) (as <> bs)


### PR DESCRIPTION
This PR implements tactic tracing; eg for `foldr`  it produces this trace:

```
auto
`- intros {f_b, b, l_a}
   `- destruct(auto)
      `- destruct l_a
         +- match [] {}
         |  `- assume b
         `- match : {a, l_a4}
            `- apply' f_b
               +- assume a
               `- recursion
                  `- apply' myfoldr
                     +- assume f_b
                     +- assume b
                     `- assume l_a4
```

Fixes #25 