### PR TITLE
Split tactic for datatypes

### DIFF
--- a/plugins/tactics/src/Ide/Plugin/Tactic.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic.hs
@@ -21,7 +21,6 @@ import           Control.Monad.Trans.Maybe
 import           Data.Aeson
 import           Data.Coerce
 import qualified Data.Foldable as F
-import qualified Data.List as L
 import qualified Data.Map as M
 import           Data.Maybe
 import qualified Data.Set as S
@@ -38,7 +37,7 @@ import           Development.Shake (Action)
 import           DynFlags (xopt)
 import qualified FastString
 import           GHC.Generics (Generic)
-import           GHC.LanguageExtensions.Type (Extension (LambdaCase, MagicHash))
+import           GHC.LanguageExtensions.Type (Extension (LambdaCase))
 import           Ide.Plugin (mkLspCommand)
 import           Ide.Plugin.Tactic.Context
 import           Ide.Plugin.Tactic.GHC
@@ -95,10 +94,9 @@ commandProvider Intros =
   filterGoalType isFunction $
     provide Intros ""
 commandProvider Split =
-  foldMapGoalType (F.fold . tyDataCons) $ \dc ->
-    let cname = occNameString $ getOccName dc
-    in  requireExtensionWhen MagicHash ("#" `L.isSuffixOf` cname) $
-      provide Split $ T.pack cname
+  filterGoalType (isJust . algebraicTyCon) $
+    foldMapGoalType (F.fold . tyDataCons) $ \dc ->
+      provide Split $ T.pack $ occNameString $ getOccName dc
 commandProvider Destruct =
   filterBindingType destructFilter $ \occ _ ->
     provide Destruct $ T.pack $ occNameString occ
@@ -191,13 +189,6 @@ requireExtension ext tp dflags plId uri range jdg =
   case xopt ext dflags of
     True  -> tp dflags plId uri range jdg
     False -> pure []
-
-
-------------------------------------------------------------------------------
--- | Like 'requireExtension' but only check if the bool is @True@.
-requireExtensionWhen :: Extension -> Bool -> TacticProvider -> TacticProvider
-requireExtensionWhen ext True = requireExtension ext
-requireExtensionWhen _ False = id
 
 
 ------------------------------------------------------------------------------

--- a/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
@@ -3,6 +3,7 @@
 module Ide.Plugin.Tactic.GHC where
 
 import Data.Maybe (isJust)
+import DataCon
 import TcType
 import TyCoRep
 import TyCon
@@ -66,4 +67,12 @@ lambdaCaseable (splitFunTy_maybe -> Just (arg, res))
   | isJust (algebraicTyCon arg)
   = Just $ isJust $ algebraicTyCon res
 lambdaCaseable _ = Nothing
+
+
+------------------------------------------------------------------------------
+-- | What data-constructor, if any, does the type have?
+tyDataCons :: Type -> Maybe [DataCon]
+tyDataCons g = do
+  (tc, _) <- splitTyConApp_maybe g
+  pure $ tyConDataCons tc
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
@@ -178,15 +178,15 @@ splitDataCon dc = rule $ \jdg -> do
 -- | Attempt to instantiate the named data constructor to solve the goal.
 splitDataCon' :: OccName -> TacticsM ()
 splitDataCon' dcn = do
+  let tacname = "splitDataCon'(" ++ unsafeRender dcn ++ ")"
   jdg <- goal
   let g = jGoal jdg
-  case splitTyConApp_maybe $ unCType g of
-    Nothing -> throwError $ GoalMismatch ("splitDataCon'" ++ unsafeRender dcn) g
-    Just (tc, _) -> do
-      let dcs = tyConDataCons tc
-          mdc = find ((== dcn) . getOccName) dcs
+  case tyDataCons $ unCType g of
+    Nothing -> throwError $ GoalMismatch tacname g
+    Just dcs -> do
+      let mdc = find ((== dcn) . getOccName) dcs
       case mdc of
-        Nothing -> throwError $ GoalMismatch ("splitDataCon'" ++ unsafeRender dcn) g
+        Nothing -> throwError $ GoalMismatch tacname g
         Just dc -> splitDataCon dc
 
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/TestTypes.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/TestTypes.hs
@@ -11,6 +11,7 @@ import qualified Data.Text as T
 data TacticCommand
   = Auto
   | Intros
+  | Split
   | Destruct
   | Homomorphism
   | DestructLambdaCase
@@ -21,6 +22,7 @@ data TacticCommand
 tacticTitle :: TacticCommand -> T.Text -> T.Text
 tacticTitle Auto _ = "Attempt to fill hole"
 tacticTitle Intros _ = "Introduce lambda"
+tacticTitle Split cname = "Introduce constructor " <> cname
 tacticTitle Destruct var = "Case split on " <> var
 tacticTitle Homomorphism var = "Homomorphic case split on " <> var
 tacticTitle DestructLambdaCase _ = "Lambda case split"

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -21,6 +21,7 @@ import           Language.Haskell.LSP.Types (ApplyWorkspaceEditRequest, Position
 import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import           System.FilePath
 import System.Directory (doesFileExist)
 import Control.Monad (unless)
@@ -80,8 +81,8 @@ tests = testGroup
       "T3.hs" 7 13
       [ (id, DestructLambdaCase, "")
       ]
-  , mkTest
-      "Produces I# with -XMagicHash"
+  , ignoreTestBecause "Not implemented, see #31" $ mkTest
+      "Splits Int with I# when -XMagicHash is enabled"
       "T3.hs" 10 14
       [ (id, Split, "I#")
       ]

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -81,9 +81,15 @@ tests = testGroup
       [ (id, DestructLambdaCase, "")
       ]
   , mkTest
-      "Produces datatype split actions"
+      "Produces datatype split action for single-constructor types"
       "T2.hs" 16 14
       [ (id, Split, "T")
+      ]
+  , mkTest
+      "Produces datatype split action for multiple constructors"
+      "T2.hs" 21 15
+      [ (id, Split, "T21")
+      , (id, Split, "T22")
       ]
   , mkTest
       "Doesn't suggest lambdacase without -XLambdaCase"
@@ -100,6 +106,7 @@ tests = testGroup
   , goldenTest "GoldenPureList.hs"          2 12 Auto ""
   , goldenTest "GoldenGADTDestruct.hs"      7 17 Destruct "gadt"
   , goldenTest "GoldenGADTAuto.hs"          7 13 Auto ""
+  , goldenTest "GoldenSplitPair.hs"         2 11 Split "(,)"
   ]
 
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -81,6 +81,11 @@ tests = testGroup
       [ (id, DestructLambdaCase, "")
       ]
   , mkTest
+      "Produces I# with -XMagicHash"
+      "T3.hs" 10 14
+      [ (id, Split, "I#")
+      ]
+  , mkTest
       "Produces datatype split action for single-constructor types"
       "T2.hs" 16 14
       [ (id, Split, "T")
@@ -90,6 +95,11 @@ tests = testGroup
       "T2.hs" 21 15
       [ (id, Split, "T21")
       , (id, Split, "T22")
+      ]
+  , mkTest
+      "Doesn't suggest MagicHash constructors without -XMagicHash"
+      "T2.hs" 24 14
+      [ (not, Split, "I#")
       ]
   , mkTest
       "Doesn't suggest lambdacase without -XLambdaCase"

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -81,6 +81,11 @@ tests = testGroup
       [ (id, DestructLambdaCase, "")
       ]
   , mkTest
+      "Produces datatype split actions"
+      "T2.hs" 16 14
+      [ (id, Split, "T")
+      ]
+  , mkTest
       "Doesn't suggest lambdacase without -XLambdaCase"
       "T2.hs" 11 25
       [ (not, DestructLambdaCase, "")

--- a/test/testdata/tactic/GoldenSplitPair.hs
+++ b/test/testdata/tactic/GoldenSplitPair.hs
@@ -1,0 +1,2 @@
+thePair :: (Int, Int)
+thePair = _

--- a/test/testdata/tactic/GoldenSplitPair.hs.expected
+++ b/test/testdata/tactic/GoldenSplitPair.hs.expected
@@ -1,0 +1,2 @@
+thePair :: (Int, Int)
+thePair = ((,) _ _)

--- a/test/testdata/tactic/T2.hs
+++ b/test/testdata/tactic/T2.hs
@@ -14,3 +14,8 @@ data T = T !(Int, Int)
 
 suggestCon :: T
 suggestCon = _
+
+data T2 = T21 Int | T22 Int Int
+
+suggestCons :: T2
+suggestCons = _

--- a/test/testdata/tactic/T2.hs
+++ b/test/testdata/tactic/T2.hs
@@ -10,3 +10,7 @@ foo  = _
 dontSuggestLambdaCase :: Either a b -> Int
 dontSuggestLambdaCase = _
 
+data T = T !(Int, Int)
+
+suggestCon :: T
+suggestCon = _

--- a/test/testdata/tactic/T2.hs
+++ b/test/testdata/tactic/T2.hs
@@ -19,3 +19,6 @@ data T2 = T21 Int | T22 Int Int
 
 suggestCons :: T2
 suggestCons = _
+
+suggestInt :: Int
+suggestInt = _

--- a/test/testdata/tactic/T3.hs
+++ b/test/testdata/tactic/T3.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase, MagicHash #-}
 
 suggestHomomorphicLC :: Either a b -> Either a b
 suggestHomomorphicLC = _
@@ -6,3 +6,5 @@ suggestHomomorphicLC = _
 suggestLC :: Either a b -> Int
 suggestLC = _
 
+suggestInt :: Int
+suggestInt = _


### PR DESCRIPTION
Implements #21 but allowing datatypes with more than one constructor: one code action per constructor is produced.

In the current state, the constructor is *not* scope checked. This works fine most of the time, but might cause troubles down the line. I'm not sure how to implement scope checking correctly: imports might be qualified, renamed or specific to some constructors only. Is there existing machinery to deal with that sort of backwards name resolution inplace of just using `occName` as I did [here](https://github.com/WorldSEnder/haskell-language-server/blob/e2b529c832732167875439633c199bb54c22ac9d/plugins/tactics/src/Ide/Plugin/Tactic.hs#L98)?